### PR TITLE
Add METABOLITE to IntensityEntity enum

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ license = {file = "LICENSE"}
 name = "md_dataset"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.11"
-version = "0.11.12"
+version = "0.11.13"
 
 [project.optional-dependencies]
 r = [

--- a/src/md_dataset/models/dataset.py
+++ b/src/md_dataset/models/dataset.py
@@ -72,6 +72,7 @@ class IntensityEntity(str, Enum):
     PROTEIN = "Protein"
     PEPTIDE = "Peptide"
     GENE = "Gene"
+    METABOLITE = "Metabolite"
 
 class IntensityTableType(Enum):
     INTENSITY = "intensity"


### PR DESCRIPTION
## Summary

Adds a fourth entity type to `IntensityEntity` to match the metabolite support already present upstream in md-converter, data-set-service, and the workflow webapp.

```python
class IntensityEntity(str, Enum):
    PROTEIN = "Protein"
    PEPTIDE = "Peptide"
    GENE = "Gene"
    METABOLITE = "Metabolite"   # ← new
```

`IntensityTable.table_name(intensity_type, entity_type)` already builds the table-lookup string from `entity_type.value`, so this single value addition is enough to reach `Metabolite_Intensity` / `Metabolite_Metadata` through `input_datasets[0].table(...)`. No other code change is required.

## Why

- **md-converter** (`md_format_metabolite/reader.py`) already produces canonical `Metabolite_Intensity` and `Metabolite_Metadata` tables with required columns `GroupId` + `MetaboliteId`.
- **data-set-service** already registers metabolite search.
- **workflow webapp** already exposes a `workspace_metabolite` feature flag and surfaces metabolite as an entity type in the UI.
- Today, downstream analysis packages that depend on `IntensityEntity` (notably `MDFlexiComparisons`) cannot dispatch on `entity_type == "metabolite"` because the enum value does not exist. This addition unblocks them.

## Downstream

`MDFlexiComparisons` has a paired PR queued that adds `"metabolite"` to the pairwise + ANOVA entity-type Literal and wires the R-side metadata handling. That PR bumps its `md_dataset` pin once a release tag is cut from this commit.

## Test plan

- [ ] `python -c "from md_dataset.models.dataset import IntensityEntity; print(IntensityEntity.METABOLITE)"` → `IntensityEntity.METABOLITE`
- [ ] `python -c "from md_dataset.models.dataset import IntensityTable, IntensityTableType, IntensityEntity; print(IntensityTable.table_name(IntensityTableType.METADATA, IntensityEntity.METABOLITE))"` → `Metabolite_Metadata`
- [ ] Existing test suite passes unchanged.