### PR TITLE
Add optional factor_metadata_association table to MOFADataset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ license = {file = "LICENSE"}
 name = "md_dataset"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.11"
-version = "0.11.17"
+version = "0.11.18"
 
 [project.optional-dependencies]
 r = [

--- a/src/md_dataset/models/dataset.py
+++ b/src/md_dataset/models/dataset.py
@@ -722,6 +722,7 @@ class MOFATableType(Enum):
     FACTOR_SCORES = "factor_scores"
     FACTOR_LOADINGS = "factor_loadings"
     VARIANCE_EXPLAINED = "variance_explained"
+    FACTOR_METADATA_ASSOCIATION = "factor_metadata_association"
     RUNTIME_METADATA = "runtime_metadata"
 
 
@@ -739,12 +740,18 @@ class MOFADataset(Dataset):
     variance_explained : PandasDataFrame
         Proportion of variance in each view explained by each factor.
         Long format: view, factor, variance_r2.
+    factor_metadata_association : PandasDataFrame
+        Post-hoc association of each factor with each selected sample-metadata
+        column (which factor tracks which experimental variable). Optional —
+        present only when the run was given sample metadata.
+        Long format: factor, metadata_column, metadata_type, r2, p_value, test.
     runtime_metadata : PandasDataFrame
         Package version, parameters used, view names, sample count.
     """
     factor_scores: pd.DataFrame
     factor_loadings: pd.DataFrame
     variance_explained: pd.DataFrame
+    factor_metadata_association: pd.DataFrame = None
     runtime_metadata: pd.DataFrame = None
     _dump_cache: dict = PrivateAttr(default=None)
 
@@ -763,11 +770,12 @@ class MOFADataset(Dataset):
                 msg = f"The field '{field_name}' must be a pandas DataFrame, but got {type(value).__name__}."
                 raise TypeError(msg)
 
-        runtime_metadata = values.get("runtime_metadata")
-        if runtime_metadata is not None and not isinstance(runtime_metadata, pd.DataFrame):
-            msg = f"The field 'runtime_metadata' must be a pandas DataFrame if provided, but \
-                    got {type(runtime_metadata).__name__}."
-            raise TypeError(msg)
+        for optional in ("factor_metadata_association", "runtime_metadata"):
+            value = values.get(optional)
+            if value is not None and not isinstance(value, pd.DataFrame):
+                msg = f"The field '{optional}' must be a pandas DataFrame if provided, but \
+                        got {type(value).__name__}."
+                raise TypeError(msg)
         return values
 
     def tables(self) -> list[tuple[str, pd.DataFrame]]:
@@ -776,6 +784,8 @@ class MOFADataset(Dataset):
             (self._path(MOFATableType.FACTOR_LOADINGS), self.factor_loadings),
             (self._path(MOFATableType.VARIANCE_EXPLAINED), self.variance_explained),
         ]
+        if self.factor_metadata_association is not None:
+            tables.append((self._path(MOFATableType.FACTOR_METADATA_ASSOCIATION), self.factor_metadata_association))
         if self.runtime_metadata is not None:
             tables.append((self._path(MOFATableType.RUNTIME_METADATA), self.runtime_metadata))
         return tables
@@ -799,6 +809,12 @@ class MOFADataset(Dataset):
                     "path": self._path(MOFATableType.VARIANCE_EXPLAINED),
                 },
             ]
+            if self.factor_metadata_association is not None:
+                result_tables.append({
+                    "id": str(uuid.uuid4()),
+                    "name": "factor_metadata_association",
+                    "path": self._path(MOFATableType.FACTOR_METADATA_ASSOCIATION),
+                })
             if self.runtime_metadata is not None:
                 result_tables.append({
                     "id": str(uuid.uuid4()),

--- a/tests/test_mofa_dataset.py
+++ b/tests/test_mofa_dataset.py
@@ -1,0 +1,82 @@
+"""Unit tests for MOFADataset's output contract.
+
+Focus: the optional ``factor_metadata_association`` table — present in the
+persisted tables only when supplied, so an unsupervised MOFA run (no sample
+metadata) keeps emitting exactly the three core tables.
+"""
+
+from uuid import uuid4
+import pandas as pd
+import pytest
+from md_dataset.models.dataset import DatasetType
+from md_dataset.models.dataset import MOFADataset
+from md_dataset.models.dataset import MOFATableType
+
+THREE_CORE_TABLES = 3
+FOUR_TABLES_WITH_ASSOCIATION = 4
+
+
+def _core_frames() -> dict:
+    frame = pd.DataFrame({"a": [1.0, 2.0]})
+    return {"factor_scores": frame, "factor_loadings": frame, "variance_explained": frame}
+
+
+def _association_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "factor": [1, 2],
+            "metadata_column": ["condition", "condition"],
+            "metadata_type": ["categorical", "categorical"],
+            "r2": [0.71, 0.04],
+            "p_value": [0.001, 0.8],
+            "test": ["anova", "anova"],
+        },
+    )
+
+
+def test_association_table_is_an_enum_member():
+    assert MOFATableType.FACTOR_METADATA_ASSOCIATION.value == "factor_metadata_association"
+
+
+def test_unsupervised_run_emits_only_core_tables():
+    ds = MOFADataset(run_id=uuid4(), dataset_type=DatasetType.MOFA, **_core_frames())
+    names = [path.split("/")[-1].removesuffix(".parquet") for path, _ in ds.tables()]
+    assert names == ["factor_scores", "factor_loadings", "variance_explained"]
+    assert len(ds.tables()) == THREE_CORE_TABLES
+    assert [t["name"] for t in ds.dump()["tables"]] == names
+
+
+def test_association_table_persisted_when_supplied():
+    ds = MOFADataset(
+        run_id=uuid4(),
+        dataset_type=DatasetType.MOFA,
+        factor_metadata_association=_association_frame(),
+        **_core_frames(),
+    )
+    names = [path.split("/")[-1].removesuffix(".parquet") for path, _ in ds.tables()]
+    assert "factor_metadata_association" in names
+    assert len(ds.tables()) == FOUR_TABLES_WITH_ASSOCIATION
+    # dump() (the persisted manifest) lists it too.
+    assert "factor_metadata_association" in [t["name"] for t in ds.dump()["tables"]]
+
+
+def test_association_table_path_is_well_formed():
+    run_id = uuid4()
+    ds = MOFADataset(
+        run_id=run_id,
+        dataset_type=DatasetType.MOFA,
+        factor_metadata_association=_association_frame(),
+        **_core_frames(),
+    )
+    paths = {path.split("/")[-1]: path for path, _ in ds.tables()}
+    assert paths["factor_metadata_association.parquet"] == f"job_runs/{run_id}/factor_metadata_association.parquet"
+
+
+def test_association_must_be_a_dataframe_if_provided():
+    with pytest.raises(TypeError, match="factor_metadata_association"):
+        MOFADataset(
+            run_id=uuid4(),
+            dataset_type=DatasetType.MOFA,
+            factor_metadata_association="not a dataframe",
+            **_core_frames(),
+        )


### PR DESCRIPTION
## What

Adds an **optional** `factor_metadata_association` output table to `MOFADataset`.

MOFA is unsupervised — it learns latent factors, not contrasts. To interpret a factorial design you need to know *which factor tracks which experimental variable* (genotype, timepoint, sex…). The companion md-mofa change computes that association (one-way ANOVA η²/R² for categorical metadata columns, Pearson r² for numerical, with a p-value) and returns it as a fourth table. `MOFADataset` currently has fixed fields, so the factory (`MOFADataset(**tables)`) **silently drops** any extra table — this PR adds the field so it persists.

## Changes

- `MOFATableType.FACTOR_METADATA_ASSOCIATION`
- `MOFADataset.factor_metadata_association: pd.DataFrame = None` — optional, wired into `tables()` and `dump()`, with the same DataFrame type-guard as `runtime_metadata`.
- `tests/test_mofa_dataset.py` — present/absent, persisted manifest, well-formed path, type-guard (5 tests).
- Version `0.11.17 → 0.11.18`.

## Backward compatibility

Optional and mirrors `runtime_metadata`: when not supplied (an unsupervised MOFA run with no sample metadata) the dataset emits exactly the three existing tables. No existing field or path changes.

## Why now

Required by md-mofa's condition-aware MOFA feature (factor↔metadata association + sample-metadata channel + condition subsetting). Once this releases, md-mofa's `md_dataset` pin is bumped to `v0.11.18-*` so the association table reaches storage/visualisation.

Verified: 5/5 new tests pass; md-mofa's full suite passes against this `md_dataset` + `md_form@v0.2.4-47`, with the table persisting end-to-end through `create_dataset_from_run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)