### PR TITLE
Add DOSE_RESPONSE_COMPARE dataset type

### DIFF
--- a/src/md_dataset/models/dataset.py
+++ b/src/md_dataset/models/dataset.py
@@ -23,6 +23,7 @@ class DatasetType(Enum):
     INTENSITY = "INTENSITY"
     DOSE_RESPONSE = "DOSE_RESPONSE"
     DOSE_RESPONSE_AGGREGATE = "DOSE_RESPONSE_AGGREGATE"
+    DOSE_RESPONSE_COMPARE = "DOSE_RESPONSE_COMPARE"
     PAIRWISE = "PAIRWISE"
     ANOVA = "ANOVA"
     ENRICHMENT = "ENRICHMENT"
@@ -607,6 +608,116 @@ class DoseResponseDataset(Dataset):
 
     def _path(self, table_type: DoseResponseTableType) -> str:
         return f"job_runs/{self.run_id}/{table_type.value}.parquet"
+
+
+class DoseResponseCompareTableType(Enum):
+    OUTPUT_COMPARISONS = "output_comparisons"
+    OUTPUT_CURVES = "output_curves"
+    INPUT_DRC = "input_drc"
+    RUNTIME_METADATA = "runtime_metadata"
+
+
+class DoseResponseCompareDataset(Dataset):
+    """A dose-response curve-comparison dataset.
+
+    A pairwise-style comparison of dose-response curves: every feature is
+    compared treatment-vs-control across one or more comparisons. Mirrors the
+    PAIRWISE convention (one ``output_comparisons`` row per feature, with each
+    comparison's statistics in columns suffixed by the comparison label, e.g.
+    ``MaxLog2FoldChange <treatment> - <control>``) while also carrying the
+    fitted display curves so a curve-comparison viewer can plot both curves.
+
+    Attributes:
+    ----------
+    output_comparisons : PandasDataFrame
+        One row per feature; per-comparison statistics in suffixed columns
+        (``MaxLog2FoldChange ...``, ``PValue ...``, ``AdjPValue ...``) plus the
+        entity-metadata columns (``GroupId``, ``GroupLabel``, ``GroupLabelType``,
+        ``GeneNames``, ``Description``, ``ProteinIds``).
+    output_curves : PandasDataFrame
+        Fitted control/compound curves over a dose grid (one row per
+        feature x comparison x condition x grid point).
+    input_drc : PandasDataFrame
+        Per feature x sample input table (optional; for debugging / re-fitting).
+    runtime_metadata : PandasDataFrame
+        Information about the dataset at runtime (parameters, fit method).
+    """
+    output_comparisons: pd.DataFrame
+    output_curves: pd.DataFrame
+    input_drc: pd.DataFrame = None
+    runtime_metadata: pd.DataFrame = None
+    _dump_cache: dict = PrivateAttr(default=None)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    @model_validator(mode="before")
+    def validate_dataframes(cls, values: dict) -> dict:
+        required_fields = ["output_comparisons", "output_curves"]
+        for field_name in required_fields:
+            value = values.get(field_name)
+            if value is None:
+                msg = f"The field '{field_name}' must be set and cannot be None."
+                raise ValueError(msg)
+            if not isinstance(value, pd.DataFrame):
+                msg = f"The field '{field_name}' must be a pandas DataFrame, but got {type(value).__name__}."
+                raise TypeError(msg)
+
+        for optional in ("input_drc", "runtime_metadata"):
+            value = values.get(optional)
+            if value is not None and not isinstance(value, pd.DataFrame):
+                msg = f"The field '{optional}' must be a pandas DataFrame if provided, but \
+                        got {type(value).__name__}."
+                raise TypeError(msg)
+        return values
+
+    def tables(self) -> list[tuple[str, pd.DataFrame]]:
+        tables = [
+            (self._path(DoseResponseCompareTableType.OUTPUT_COMPARISONS), self.output_comparisons),
+            (self._path(DoseResponseCompareTableType.OUTPUT_CURVES), self.output_curves),
+        ]
+        if self.input_drc is not None:
+            tables.append((self._path(DoseResponseCompareTableType.INPUT_DRC), self.input_drc))
+        if self.runtime_metadata is not None:
+            tables.append((self._path(DoseResponseCompareTableType.RUNTIME_METADATA), self.runtime_metadata))
+        return tables
+
+    def dump(self) -> dict:
+        if self._dump_cache is None:
+            result_tables = [
+                {
+                    "id": str(uuid.uuid4()),
+                    "name": "output_comparisons",
+                    "path": self._path(DoseResponseCompareTableType.OUTPUT_COMPARISONS),
+                },
+                {
+                    "id": str(uuid.uuid4()),
+                    "name": "output_curves",
+                    "path": self._path(DoseResponseCompareTableType.OUTPUT_CURVES),
+                },
+            ]
+            if self.input_drc is not None:
+                result_tables.append({
+                    "id": str(uuid.uuid4()),
+                    "name": "input_drc",
+                    "path": self._path(DoseResponseCompareTableType.INPUT_DRC),
+                })
+            if self.runtime_metadata is not None:
+                result_tables.append({
+                    "id": str(uuid.uuid4()),
+                    "name": "runtime_metadata",
+                    "path": self._path(DoseResponseCompareTableType.RUNTIME_METADATA),
+                })
+            self._dump_cache = {
+                "type": self.dataset_type,
+                "run_id": self.run_id,
+                "tables": result_tables,
+            }
+        return self._dump_cache
+
+    def _path(self, table_type: DoseResponseCompareTableType) -> str:
+        return f"job_runs/{self.run_id}/{table_type.value}.parquet"
+
 
 class LegacyIntensityDataset(Dataset):
     """An intentisy dataset.

--- a/src/md_dataset/models/factory.py
+++ b/src/md_dataset/models/factory.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from md_dataset.models.dataset import AnovaDataset
 from md_dataset.models.dataset import Dataset
 from md_dataset.models.dataset import DatasetType
+from md_dataset.models.dataset import DoseResponseCompareDataset
 from md_dataset.models.dataset import DoseResponseDataset
 from md_dataset.models.dataset import EnrichmentDataset
 from md_dataset.models.dataset import IntensityDataset
@@ -24,6 +25,8 @@ _DATASET_REGISTRY = {
             tables: AnovaDataset(run_id=run_id, dataset_type=dataset_type, **tables),
     (DatasetType.DOSE_RESPONSE, dict): lambda run_id, dataset_type, \
             tables: DoseResponseDataset(run_id=run_id, dataset_type=dataset_type, **tables),
+    (DatasetType.DOSE_RESPONSE_COMPARE, dict): lambda run_id, dataset_type, \
+            tables: DoseResponseCompareDataset(run_id=run_id, dataset_type=dataset_type, **tables),
     (DatasetType.ENRICHMENT, dict): lambda run_id, dataset_type, \
             tables: EnrichmentDataset(run_id=run_id, dataset_type=dataset_type, **tables),
     (DatasetType.ORA, dict): lambda run_id, dataset_type, \

--- a/tests/test_dose_response_compare_dataset.py
+++ b/tests/test_dose_response_compare_dataset.py
@@ -1,0 +1,77 @@
+"""Round-trip tests for the DOSE_RESPONSE_COMPARE dataset type."""
+
+import uuid
+import pandas as pd
+import pytest
+from md_dataset.models.dataset import DatasetType
+from md_dataset.models.dataset import DoseResponseCompareDataset
+from md_dataset.models.factory import create_dataset_from_run
+
+
+def _df(**cols: object) -> pd.DataFrame:
+    return pd.DataFrame(cols)
+
+
+def _comparisons() -> pd.DataFrame:
+    return _df(GroupId=[1, 2], **{"MaxLog2FoldChange A - B": [1.0, -2.0]})
+
+
+def _curves() -> pd.DataFrame:
+    return _df(GroupId=[1, 1], Dose=[0.1, 1.0], DrcPred=[5.0, 6.0])
+
+
+def _make(**extra: pd.DataFrame) -> DoseResponseCompareDataset:
+    return DoseResponseCompareDataset(
+        run_id=uuid.uuid4(),
+        dataset_type=DatasetType.DOSE_RESPONSE_COMPARE,
+        output_comparisons=_comparisons(),
+        output_curves=_curves(),
+        **extra,
+    )
+
+
+def test_dump_table_names_and_paths():
+    ds = _make(runtime_metadata=_df(FitMethod=["loess"]))
+    dump = ds.dump()
+    assert dump["type"] == DatasetType.DOSE_RESPONSE_COMPARE
+    names = [t["name"] for t in dump["tables"]]
+    assert names == ["output_comparisons", "output_curves", "runtime_metadata"]
+    for t in dump["tables"]:
+        assert t["path"] == f"job_runs/{ds.run_id}/{t['name']}.parquet"
+
+
+def test_dump_is_cached():
+    ds = _make()
+    assert ds.dump() is ds.dump()
+
+
+def test_input_drc_omitted_by_default():
+    ds = _make()
+    assert [n for n, _ in ds.tables()].count(f"job_runs/{ds.run_id}/input_drc.parquet") == 0
+    assert [t["name"] for t in ds.dump()["tables"]] == ["output_comparisons", "output_curves"]
+
+
+def test_input_drc_included_when_provided():
+    ds = _make(input_drc=_df(GroupId=[1], replicate=["s1"], InitialIntensity=[5.0]))
+    assert [t["name"] for t in ds.dump()["tables"]] == [
+        "output_comparisons",
+        "output_curves",
+        "input_drc",
+    ]
+
+
+def test_factory_creates_dose_response_compare():
+    run_id = uuid.uuid4()
+    tables = {"output_comparisons": _comparisons(), "output_curves": _curves()}
+    ds = create_dataset_from_run(run_id, DatasetType.DOSE_RESPONSE_COMPARE, tables)
+    assert isinstance(ds, DoseResponseCompareDataset)
+    assert [t["name"] for t in ds.dump()["tables"]] == ["output_comparisons", "output_curves"]
+
+
+def test_missing_required_output_curves_raises():
+    with pytest.raises(ValueError, match="output_curves"):
+        DoseResponseCompareDataset(
+            run_id=uuid.uuid4(),
+            dataset_type=DatasetType.DOSE_RESPONSE_COMPARE,
+            output_comparisons=_comparisons(),
+        )


### PR DESCRIPTION
## What

Adds a new `DOSE_RESPONSE_COMPARE` dataset type — a **pairwise-style comparison of dose-response curves**. Mirrors the `Add ORA dataset type` change (enum + class + factory entry), plus a round-trip test.

Each feature is compared treatment-vs-control across one or more comparisons:

- **`output_comparisons`** — one row per feature; each comparison's stats live in **columns suffixed by the comparison label** (the PAIRWISE convention), so a comparison volcano can select a comparison by reading its columns:
  - `MaxLog2FoldChange <treatment> - <control>`
  - `PValue <treatment> - <control>`
  - `AdjPValue <treatment> - <control>`
  - plus entity-agnostic metadata: `GroupId`, `GroupLabel`, `GroupLabelType`, `GeneNames`, `Description`, `ProteinIds`.
- **`output_curves`** — fitted control/compound curves over a dose grid (required).
- **`input_drc`**, **`runtime_metadata`** — optional.

The entity-agnostic metadata (`GroupLabelType`) means the **same type serves protein- and peptide-level** datasets.

## Why

The dose-response curve-**comparison** workflow (`MDDoseResponseCompare` / DRtC) currently has to masquerade as `DOSE_RESPONSE`, whose volcano cannot facet by comparison and whose native columns mislabel the effect size. A comparison result is structurally pairwise, so it needs its own type to be consumed correctly (a comparison volcano + a two-curve comparison plot, built in a follow-up).

## Changes

- `models/dataset.py`: `DatasetType.DOSE_RESPONSE_COMPARE`, `DoseResponseCompareTableType`, `DoseResponseCompareDataset` (`output_comparisons` + `output_curves` required; `input_drc` + `runtime_metadata` optional).
- `models/factory.py`: registry entry (`(DOSE_RESPONSE_COMPARE, dict)`), so the in-flow write path (`create_dataset_from_run`) can construct it.
- `tests/test_dose_response_compare_dataset.py`: dump/tables/factory round-trip + validation (6 tests).

No version bump (releases are promoted separately, as with the ORA change). `ruff` clean; new + existing dataset tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)